### PR TITLE
Permet de poser une question via la nouvelle interface utilisateur

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -38,7 +38,7 @@ class Mode(StrEnum):
 class Configuration(NamedTuple):
     albert: Albert
     base_de_donnees: BaseDeDonnees
-    host: str
+    hote: str
     port: int
     mode: Mode
 
@@ -76,7 +76,7 @@ def recupere_configuration() -> Configuration:
     return Configuration(
         albert=configuration_albert,
         base_de_donnees=configuration_base_de_donnees,
-        host=os.getenv("HOST", "127.0.0.1"),
+        hote=os.getenv("HOST", "127.0.0.1"),
         port=int(os.getenv("PORT", "8000")),
         mode=mode,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ configuration = recupere_configuration()
 serveur = fabrique_serveur(configuration.mode)
 
 if __name__ == "__main__":
-    HOST = configuration.host
+    HOST = configuration.hote
     PORT = configuration.port
     uvicorn.run(
         "main:serveur",

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MesQuestionsCyber</title>
   </head>

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1,8 +1,50 @@
 <script lang="ts">
+  export let url_api: string;
+
+  type Paragraphe = {
+    score_similarite: number,
+    numero_page: number,
+    url: string,
+    nom_document: string,
+    contenu: string,
+  };
+
+  let reponse: string;
+  let references: Paragraphe[];
+
+  async function soumetQuestion(e: Event) {
+    const question = ((e!.target as HTMLFormElement)!.elements[0] as HTMLInputElement)!.value;
+
+    const endpoint = `${url_api}/api/pose_question`;
+
+    const retour_application = (await (await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ question }),
+    })).json());
+
+    reponse = retour_application.reponse;
+    references = retour_application.paragraphes;
+  }
 </script>
 
 <main>
   <div>Mes Questions Cyber</div>
+
+  <div>{reponse}</div>
+
+  <ul>{#each references as reference (`${reference.url}${reference.contenu}`)}
+    <li>
+      <a href="{reference.url}">{reference.nom_document}, p.{reference.numero_page}</a>
+    </li>
+  {/each}</ul>
+
+  <form on:submit|preventDefault={soumetQuestion}>
+    <input placeholder="Posez votre question cyber"/>
+    <input type="submit">
+  </form>
 </main>
 
 <style>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -4,6 +4,9 @@ import App from "./App.svelte";
 
 const app = mount(App, {
   target: document.getElementById("app")!,
+  props: {
+    url_api: "http://localhost:3003",
+  },
 });
 
 export default app;


### PR DESCRIPTION
On commence à migrer les fonctionnalités de notre prototype `gradio` vers la nouvelle UI faite en `svelte`.
Ici, la possibilité de poser une question et d'en afficher la réponse.

<img width="743" height="80" alt="page avec formulaire vide" src="https://github.com/user-attachments/assets/e4b1c043-f943-455d-b872-7ab309846df2" />

<img width="1561" height="114" alt="page avec reponse, et formulaire rempli" src="https://github.com/user-attachments/assets/b908ec2b-7c7e-4f0a-a4ce-3154feabfac4" />
