### PR TITLE
[SOIN] Enlève une fonctionnalité inutile : la collection de statistique sur les retours

### DIFF
--- a/src/adaptateurs/adaptateur_base_de_donnees.py
+++ b/src/adaptateurs/adaptateur_base_de_donnees.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Optional
 from schemas.retour_utilisatrice import RetourUtilisatrice, Interaction
 from schemas.client_albert import ReponseQuestion
 
@@ -17,10 +17,6 @@ class AdaptateurBaseDeDonnees(ABC):
 
     @abstractmethod
     def lit_interaction(self, identifiant_interaction: str) -> Optional[Interaction]:
-        pass
-
-    @abstractmethod
-    def obtient_statistiques(self) -> Dict[str, int]:
         pass
 
     @abstractmethod

--- a/src/adaptateurs/adaptateur_base_de_donnees_memoire.py
+++ b/src/adaptateurs/adaptateur_base_de_donnees_memoire.py
@@ -33,22 +33,5 @@ class AdaptateurBaseDeDonneesEnMemoire(AdaptateurBaseDeDonnees):
     def lit_interaction(self, identifiant_interaction: str) -> Optional[Interaction]:
         return self._interactions.get(identifiant_interaction)
 
-    def obtient_statistiques(self) -> Dict[str, int]:
-        total_interactions = len(self._interactions)
-        total_retours = 0
-        pouces_leves = 0
-
-        for interaction in self._interactions.values():
-            if interaction.retour_utilisatrice is not None:
-                total_retours += 1
-                if interaction.retour_utilisatrice.pouce_leve:
-                    pouces_leves += 1
-
-        return {
-            "total_interactions": total_interactions,
-            "total_retours": total_retours,
-            "pouces_leves": pouces_leves,
-        }
-
     def ferme_connexion(self) -> None:
         self._interactions.clear()

--- a/src/adaptateurs/adaptateur_base_de_donnees_postgres.py
+++ b/src/adaptateurs/adaptateur_base_de_donnees_postgres.py
@@ -1,7 +1,7 @@
 import uuid
 import psycopg2
 import psycopg2.extras
-from typing import Dict, Optional, Tuple, cast
+from typing import Optional
 from schemas.retour_utilisatrice import RetourUtilisatrice, Interaction
 from schemas.client_albert import ReponseQuestion
 from configuration import recupere_configuration_postgres, recupere_configuration
@@ -84,31 +84,6 @@ class AdaptateurBaseDeDonneesPostgres(AdaptateurBaseDeDonnees):
                 return None
 
         return Interaction.model_validate(ligne["contenu"])
-
-    def obtient_statistiques(self) -> Dict[str, int]:
-        with self._connexion.cursor() as curseur:
-            curseur.execute("SELECT COUNT(*) FROM interactions")
-            # Comme la requête nous retourne une seule colonne contenant un compte,
-            # on peut caster, puis interpréter comme un entier.
-            total_interactions = int(cast(Tuple[str], curseur.fetchone())[0])
-
-            curseur.execute("SELECT contenu FROM interactions")
-            lignes = curseur.fetchall()
-        total_retours = 0
-        pouces_leves = 0
-
-        for ligne in lignes:
-            interaction = Interaction.model_validate(ligne[0])
-            if interaction.retour_utilisatrice is not None:
-                total_retours += 1
-                if interaction.retour_utilisatrice.pouce_leve:
-                    pouces_leves += 1
-
-        return {
-            "total_interactions": total_interactions,
-            "total_retours": total_retours,
-            "pouces_leves": pouces_leves,
-        }
 
     def ferme_connexion(self) -> None:
         if self._connexion:

--- a/tests/test_adaptateur_base_de_donnees.py
+++ b/tests/test_adaptateur_base_de_donnees.py
@@ -97,46 +97,6 @@ def test_ajout_retour_utilisatrice(adaptateur_test) -> None:
     assert resultat is True
 
 
-def test_recuperation_statistiques(adaptateur_test) -> None:
-    reponse1 = ReponseQuestion(
-        reponse="Réponse 1", paragraphes=[], question="Question 1"
-    )
-    reponse2 = ReponseQuestion(
-        reponse="Réponse 2", paragraphes=[], question="Question 2"
-    )
-
-    id1 = adaptateur_test.sauvegarde_interaction(reponse1)
-    id2 = adaptateur_test.sauvegarde_interaction(reponse2)
-
-    adaptateur_test.ajoute_retour_utilisatrice(id1, RetourUtilisatrice(pouce_leve=True))
-    adaptateur_test.ajoute_retour_utilisatrice(
-        id2, RetourUtilisatrice(pouce_leve=False)
-    )
-
-    stats = adaptateur_test.obtient_statistiques()
-
-    assert "total_interactions" in stats
-    assert "total_retours" in stats
-    assert "pouces_leves" in stats
-    assert stats["total_interactions"] == 2
-    assert stats["total_retours"] == 2
-    assert stats["pouces_leves"] == 1
-
-
-def test_recuperation_statistiques_sans_retour_utilisateur(adaptateur_test) -> None:
-    reponse1 = ReponseQuestion(
-        reponse="Réponse 1", paragraphes=[], question="Question 1"
-    )
-
-    adaptateur_test.sauvegarde_interaction(reponse1)
-
-    stats = adaptateur_test.obtient_statistiques()
-
-    assert stats["total_interactions"] == 1
-    assert stats["total_retours"] == 0
-    assert stats["pouces_leves"] == 0
-
-
 def test_lit_interaction_existante(adaptateur_test) -> None:
     reponse_question = ReponseQuestion(
         reponse="Réponse test", paragraphes=[], question="Question test"


### PR DESCRIPTION
C'est au milieu du chemin, ce n'est pas utile, et ça sera pas fait comme ça plus tard.

* ça demande de la maintenance, et ça complexifie les évolutions de notre modèle de données
* ce n'est pour le moment pas utilisé :
  * exposé sur aucune route
  * on a aucun utilisateurice
* ça prendra probablement une forme différente : plutôt via `metabase` et des dashboards que via une API