### PR TITLE
[SOIN] Corrige la représentation des retours, et enlève duplication de code

### DIFF
--- a/src/gradio_app.py
+++ b/src/gradio_app.py
@@ -156,7 +156,7 @@ def cree_interface_gradio(app):
                 payload = {
                     "id_interaction_rattachee": interaction_id,
                     "retour": {
-                        "pouce_leve": bool(pouce_leve),
+                        "type": "positif" if pouce_leve else "negatif",
                         "commentaire": (commentaire.strip() or None)
                         if commentaire is not None
                         else None,

--- a/src/serveur.py
+++ b/src/serveur.py
@@ -10,10 +10,7 @@ from adaptateurs import AdaptateurBaseDeDonnees
 from adaptateurs.adaptateur_base_de_donnees_postgres import (
     fabrique_adaptateur_base_de_donnees_retour_utilisatrice,
 )
-from schemas.retour_utilisatrice import (
-    RetourUtilisatrice,
-    DonneesCreationRetourUtilisateur,
-)
+from schemas.retour_utilisatrice import DonneesCreationRetourUtilisateur
 from configuration import Mode
 
 api = APIRouter(prefix="/api")
@@ -70,11 +67,8 @@ def route_retour(
         fabrique_adaptateur_base_de_donnees_retour_utilisatrice
     ),
 ) -> Dict[str, Any]:
-    retour = RetourUtilisatrice(
-        pouce_leve=body.retour.pouce_leve, commentaire=body.retour.commentaire
-    )
     succes = adaptateur_base_de_donnes.ajoute_retour_utilisatrice(
-        body.id_interaction_rattachee, retour
+        body.id_interaction_rattachee, body.retour
     )
 
     if not succes:

--- a/tests/routes/test_toutes_les_autres.py
+++ b/tests/routes/test_toutes_les_autres.py
@@ -219,7 +219,7 @@ def test_route_retour_avec_mock_retourne_succes_200() -> None:
         payload = {
             "id_interaction_rattachee": "id-123",
             "retour": {
-                "pouce_leve": True,
+                "type": "positif",
                 "commentaire": "Très utile",
             },
         }
@@ -244,7 +244,7 @@ def test_route_retour_avec_mock_retourne_donnees_attendues() -> None:
         payload = {
             "id_interaction_rattachee": "id-123",
             "retour": {
-                "pouce_leve": True,
+                "type": "positif",
                 "commentaire": "Très utile !",
             },
         }
@@ -272,7 +272,7 @@ def test_route_retour_avec_interaction_inexistante_retourne_404() -> None:
         payload = {
             "id_interaction_rattachee": "id-123",
             "retour": {
-                "pouce_leve": True,
+                "type": "positif",
                 "commentaire": "Très utile",
             },
         }
@@ -299,7 +299,7 @@ def test_route_retour_avec_payload_invalide_rejette_la_requete() -> None:
         payload = {
             "id": 23,
             "retour": {
-                "pouce_leve": True,
+                "type": "positif",
                 "commentaire": "Très utile",
             },
         }

--- a/tests/test_adaptateur_base_de_donnees.py
+++ b/tests/test_adaptateur_base_de_donnees.py
@@ -6,7 +6,7 @@ from adaptateurs import (
     AdaptateurBaseDeDonneesEnMemoire,
     AdaptateurBaseDeDonneesPostgres,
 )
-from schemas.retour_utilisatrice import RetourUtilisatrice
+from schemas.retour_utilisatrice import RetourPositif
 from schemas.client_albert import ReponseQuestion, Paragraphe
 from configuration import recupere_configuration_postgres
 
@@ -91,7 +91,7 @@ def test_ajout_retour_utilisatrice(adaptateur_test) -> None:
     )
     id_interaction = adaptateur_test.sauvegarde_interaction(reponse_question)
 
-    retour = RetourUtilisatrice(pouce_leve=True, commentaire="Très utile")
+    retour = RetourPositif(commentaire="Très utile")
 
     resultat = adaptateur_test.ajoute_retour_utilisatrice(id_interaction, retour)
     assert resultat is True
@@ -117,7 +117,7 @@ def test_lit_interaction_avec_retour_utilisatrice(adaptateur_test) -> None:
     )
     id_interaction = adaptateur_test.sauvegarde_interaction(reponse_question)
 
-    retour = RetourUtilisatrice(pouce_leve=True, commentaire="Excellent")
+    retour = RetourPositif(commentaire="Excellent")
     adaptateur_test.ajoute_retour_utilisatrice(id_interaction, retour)
 
     interaction = adaptateur_test.lit_interaction(id_interaction)
@@ -125,7 +125,6 @@ def test_lit_interaction_avec_retour_utilisatrice(adaptateur_test) -> None:
     assert interaction is not None
     assert interaction.reponse_question.reponse == "Réponse test"
     assert interaction.retour_utilisatrice is not None
-    assert interaction.retour_utilisatrice.pouce_leve is True
     assert interaction.retour_utilisatrice.commentaire == "Excellent"
 
 

--- a/tests/test_modeles_retour_utilisatrice.py
+++ b/tests/test_modeles_retour_utilisatrice.py
@@ -1,52 +1,43 @@
-from schemas.retour_utilisatrice import RetourUtilisatrice, Interaction
+from schemas.retour_utilisatrice import (
+    RetourNegatif,
+    RetourPositif,
+    RetourUtilisatrice,
+    Interaction,
+)
 from schemas.client_albert import ReponseQuestion, Paragraphe
 import pytest
 
 
 class TestRetourUtilisatrice:
-    def test_creation_complet(self) -> None:
-        retour = RetourUtilisatrice(
-            pouce_leve=True, commentaire="Réponse très claire et précise"
-        )
-
-        assert retour.pouce_leve is True
-        assert retour.commentaire == "Réponse très claire et précise"
+    def test_creation_retour_negatif_sans_commentaire_est_horodate(self) -> None:
+        retour = RetourPositif()
         assert retour.horodatage is not None
 
-    def test_creation_pouce_seul(self) -> None:
-        retour = RetourUtilisatrice(pouce_leve=True)
-
-        assert retour.pouce_leve is True
-        assert retour.commentaire is None
+    def test_creation_retour_positif_sans_commentaire_est_horodate(self) -> None:
+        retour = RetourPositif()
         assert retour.horodatage is not None
 
-    def test_creation_commentaire_seul(self) -> None:
-        retour = RetourUtilisatrice(commentaire="Très utile")
+    def test_creation_retour_negatif_avec_commentaire_contient_commentaire_et_est_horodate(
+        self,
+    ) -> None:
+        commentaire = "c'est pas terrible..."
+        retour = RetourNegatif(commentaire=commentaire)
 
-        assert retour.pouce_leve is None
-        assert retour.commentaire == "Très utile"
+        assert retour.commentaire == commentaire
         assert retour.horodatage is not None
 
-    def test_creation_vide_echoue(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match="Au moins 'pouce_leve' ou 'commentaire' doit être renseigné",
-        ):
-            RetourUtilisatrice()
+    def test_creation_retour_positif_avec_commentaire_contient_commentaire_et_est_horodate(
+        self,
+    ) -> None:
+        commentaire = "c'est super !"
+        retour = RetourPositif(commentaire=commentaire)
 
-    def test_creation_commentaire_vide_echoue(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match="Au moins 'pouce_leve' ou 'commentaire' doit être renseigné",
-        ):
-            RetourUtilisatrice(commentaire="")
+        assert retour.commentaire == commentaire
+        assert retour.horodatage is not None
 
-    def test_creation_avec_valeurs_nulles_echoue(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match="Au moins 'pouce_leve' ou 'commentaire' doit être renseigné",
-        ):
-            RetourUtilisatrice(pouce_leve=None, commentaire=None)
+    def test_creation_retour_utilisatrice_directement_echoue(self) -> None:
+        with pytest.raises(TypeError):
+            RetourUtilisatrice()  # type: ignore [operator]
 
 
 class TestInteraction:
@@ -65,9 +56,7 @@ class TestInteraction:
             question="Quelle est la longueur recommandée pour un mot de passe ?",
         )
 
-        retour_utilisatrice = RetourUtilisatrice(
-            pouce_leve=True, commentaire="Très utile"
-        )
+        retour_utilisatrice = RetourPositif(commentaire="Très utile")
 
         interaction = Interaction(
             reponse_question=reponse_question, retour_utilisatrice=retour_utilisatrice
@@ -78,7 +67,6 @@ class TestInteraction:
             == "Quelle est la longueur recommandée pour un mot de passe ?"
         )
         assert interaction.retour_utilisatrice is not None
-        assert interaction.retour_utilisatrice.pouce_leve is True
         assert interaction.retour_utilisatrice.commentaire == "Très utile"
 
     def test_creation_interaction_sans_retour_utilisatrice(self) -> None:


### PR DESCRIPTION
Le premier pour empêcher des valeurs illégales d'être représentées, et faciliter l'utilisation via l'UI.
Le second pour nettoyer et faciliter l'usage.