### PR TITLE
[CORRECTION] Évite la redirection temporaire lors de la création de la conversation

### DIFF
--- a/ui/src/client.api.ts
+++ b/ui/src/client.api.ts
@@ -67,7 +67,7 @@ export type ReponseEnErreur = {
 const creeUneConversation = async (
   message: MessageUtilisateurAPI
 ): Promise<ReponseCreationConversation | ReponseEnErreur> => {
-  const endpoint = '/api/conversation';
+  const endpoint = '/api/conversation/';
 
   const reponse = await fetch(forgeURLAvecTypeUtilisateur(endpoint), {
     method: 'POST',


### PR DESCRIPTION
… car FastAPI exécute une redirection temporaire automatique lorsque le ’/’ sur une ressource est omis