### PR TITLE
[CORRECTION] Affiche la question lorsqu’un·e utilisateur·rice choisit une suggestion

### DIFF
--- a/ui/src/composants/Introduction.svelte
+++ b/ui/src/composants/Introduction.svelte
@@ -8,6 +8,7 @@
     e.preventDefault();
     const suggestion: string = e.currentTarget.label;
     storeAffichage.estEnAttenteDeReponse(true);
+    storeConversation.questionEnAttenteDeReponse(suggestion);
     await storeAffichage.scrollVersDernierMessage();
     await storeConversation.ajouteMessageUtilisateur({ question: suggestion });
     await storeAffichage.scrollVersDernierMessage();


### PR DESCRIPTION
**Contexte**
Un·e utilisateur·rice pose une question sur MQC en choisissant une suggestion parmi celles proposées

**Reproduction**
- Se rendre sur MQC
- Poser une question, en cliquant sur une des suggestions

**Résultat constaté**
La question n’est pas affichée et un petit encart gris apparaît (cf capture)

<img width="1082" height="473" alt="question_disparait" src="https://github.com/user-attachments/assets/07c61cb1-9582-4b21-bc59-0c939fea239a" />


**Résultat attendu**
La question s’affiche dès que l’utilisateur·rice l’a envoyée