### PR TITLE
[CORRECTION] Active le bouton suivant lorsque les sources sont chargées

### DIFF
--- a/ui/src/composants/SourcesConversation.svelte
+++ b/ui/src/composants/SourcesConversation.svelte
@@ -58,7 +58,7 @@
           kind="secondary"
           size="sm"
           disabled={message.references === undefined ||
-            sourceCourante < message.references.length - 1}
+            sourceCourante === message.references.length - 1}
           onclick={deplaceADroite}
         ></dsfr-button>
       </div>


### PR DESCRIPTION
Le bouton `Suivant` est désactivé lorsque les sources sont chargées
<img width="1219" height="194" alt="suivant_desactive" src="https://github.com/user-attachments/assets/f635d610-38a0-4432-b741-a4d9d126d67a" />

Il est maintenant activé
<img width="1328" height="276" alt="suivant_affiche" src="https://github.com/user-attachments/assets/64795525-1b1e-48d8-b188-27d0cadea80e" />
