### PR TITLE
[CORRECTION] Fais défiler horizontalement via les botons suivant ou précédent le conteneur de source cible

### DIFF
--- a/ui/src/composants/SourcesConversation.svelte
+++ b/ui/src/composants/SourcesConversation.svelte
@@ -8,12 +8,12 @@
   const { message }: Props = $props();
 
   let sourceCourante = $state(0);
+  let listeElement: HTMLDivElement | undefined = $state();
 
   const deplaceADroite = () => {
-    const liste = document.querySelector('.sources-liste');
-    if (liste) {
+    if (listeElement) {
       sourceCourante += 1;
-      const elementListe = liste.children.item(sourceCourante);
+      const elementListe = listeElement.children.item(sourceCourante);
       elementListe?.scrollIntoView({
         behavior: 'smooth',
         block: 'nearest',
@@ -23,10 +23,9 @@
   };
 
   const deplaceAGauche = () => {
-    const liste = document.querySelector('.sources-liste');
-    if (liste) {
+    if (listeElement) {
       sourceCourante -= 1;
-      const elementListe = liste.children.item(sourceCourante);
+      const elementListe = listeElement.children.item(sourceCourante);
       elementListe?.scrollIntoView({
         behavior: 'smooth',
         block: 'nearest',
@@ -62,7 +61,7 @@
           onclick={deplaceADroite}
         ></dsfr-button>
       </div>
-      <div class="sources-liste">
+      <div class="sources-liste" bind:this={listeElement}>
         {#each message.references as reference, index (index)}
           {@const titreDuLien =
             reference.numero_page > 0


### PR DESCRIPTION
### Contexte
Défilement des sources affichées lors d’une conversation

### Reproduction
- Se rendre sur MQC
- Poser une question
- Poser une seconde question en rapport avec la première
- Faire défiler l’écran jusqu’aux sources de la nouvelle réponse
- Cliquer sur le bouton suivant

### Résultat constaté
Ce sont les sources de la première réponse qui défilent horizontalement

### Résultat attendu
Seules les sources attachées aux boutons suivant et précédent peuvent défiler