### PR TITLE
[CORRECTION] Scrolle sur la question lorsque l’utilisateur·rice pose une question

### DIFF
--- a/ui/src/composants/Conversation.svelte
+++ b/ui/src/composants/Conversation.svelte
@@ -43,7 +43,18 @@
       if (!container) {
         return;
       }
-      const leDernierMessage = [...container.querySelectorAll('.message')]
+      const leDernierMessage = [...container.querySelectorAll('.utilisateur')]
+        .filter((element) => !(element as HTMLElement).inert)
+        .at(-1);
+      leDernierMessage?.scrollIntoView({ block: 'start' });
+    });
+  });
+
+  $effect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    $storeAffichage.enAttenteDeReponse;
+    tick().then(() => {
+      const leDernierMessage = [...document.querySelectorAll('.utilisateur')]
         .filter((element) => !(element as HTMLElement).inert)
         .at(-1);
       leDernierMessage?.scrollIntoView({ block: 'start' });


### PR DESCRIPTION
### Contexte
L’utilisateur·rice pose une question

### Reproduction
- Poser une question sur MQC
- Attendre la réponse
- Ne pas scroller sur la page
- Poser une nouvelle question

### Résultat constaté
Lorsque la première réponse apparaît, l’affichage scrolle vers la réponse. Si l’utilisateur·rice pose une nouvelle question, l’affichage reste où il est et lorsque la réponse est disponible, l’affichage scrolle sur la nouvelle réponse.
On perd de vue la question.

<img width="889" height="965" alt="question_non_visible" src="https://github.com/user-attachments/assets/c1dcb3f2-3d06-4de8-b4c2-2adb56323574" />


### Résultat attendu
- Lorsque q’une question est posée, on scrolle sur la question.
- Lorsque la réponse est reçue, on conserve la visibilité sur la question.

<img width="896" height="684" alt="question_visible" src="https://github.com/user-attachments/assets/74b1967e-6f35-4547-8d40-fb187137f153" />

