### PR TITLE
[CORRECTION] Harmonise le nombre de résultats retournés par la recherche

### DIFF
--- a/src/services/service_albert.py
+++ b/src/services/service_albert.py
@@ -80,11 +80,9 @@ class ServiceAlbert:
 
     def recherche_paragraphes(self, question: str) -> list[Paragraphe]:
         methode_recherche = "hybrid" if self.utilise_recherche_hybride else "semantic"
-        nombre_paragraphes_a_retourner = self.nombre_paragraphes
-
         payload_classique = RecherchePayload(
             collection_ids=[self.id_collection],
-            limit=10 if self.jeopardy_active else nombre_paragraphes_a_retourner,
+            limit=self.nombre_paragraphes,
             prompt=question,
             method=methode_recherche,
         )
@@ -130,7 +128,7 @@ class ServiceAlbert:
                     paragraphes_uniques.append(p)
                     contenus_vus.add(p.contenu)
 
-            return paragraphes_uniques[:nombre_paragraphes_a_retourner]
+            return paragraphes_uniques
         else:
             return paragraphes_classiques
 
@@ -138,7 +136,7 @@ class ServiceAlbert:
         methode_recherche = "hybrid" if self.utilise_recherche_hybride else "semantic"
         payload = RecherchePayload(
             collection_ids=[self.id_collection_jeopardy],
-            limit=10,
+            limit=self.nombre_paragraphes,
             prompt=question,
             method=methode_recherche,
         )

--- a/tests/mocks/client_albert_de_test.py
+++ b/tests/mocks/client_albert_de_test.py
@@ -185,7 +185,7 @@ class ClientAlbertMemoire(ClientAlbert):
                 else []
             )
             self.appels_recherche += 1
-            return resultat
+            return resultat[: payload.limit]
 
         return self.resultats if self.resultats_vides is False else []
 
@@ -193,7 +193,7 @@ class ClientAlbertMemoire(ClientAlbert):
         self, payload: RecherchePayload
     ) -> list[ResultatRechercheJeopardy]:
         self.payload_jeopardy_recu = payload
-        return self.resultats_jeopardy
+        return self.resultats_jeopardy[: payload.limit]
 
     def recherche_chunk_par_id(
         self, id_document: str, id_chunk: int

--- a/tests/services/test_service_albert_jeopardy.py
+++ b/tests/services/test_service_albert_jeopardy.py
@@ -208,17 +208,17 @@ def test_recherche_paragraphes_dedoublonne_les_chunks_communs(un_reclasseur):
     assert contenus.count("Chunk commun") == 1
 
 
-def test_recherche_paragraphes_limite_a_20_candidats(un_reclasseur):
+def test_recherche_paragraphes_retourne_5_recherches_classique_et_5_recherches_jeopardy(
+    un_reclasseur,
+):
     client_albert_memoire = ClientAlbertMemoire()
-
-    resultats_classiques = [
+    resultats_classiques_totaux = [
         un_resultat_de_recherche()
         .ayant_pour_contenu(f"Chunk classique {i}")
         .construis()
         for i in range(15)
     ]
-
-    resultats_jeopardy = [
+    resultats_jeopardy_totaux = [
         ResultatRechercheJeopardy(
             chunk=RechercheChunkJeopardy(
                 content=f"Question {i}",
@@ -232,17 +232,16 @@ def test_recherche_paragraphes_limite_a_20_candidats(un_reclasseur):
         )
         for i in range(15)
     ]
-    client_albert_memoire.avec_les_resultats_jeopardy(resultats_jeopardy)
-
-    chunks_sources_jeopardy = [
+    client_albert_memoire.avec_les_resultats_jeopardy(resultats_jeopardy_totaux)
+    chunks_sources_jeopardy_totaux = [
         un_resultat_de_recherche()
         .ayant_pour_contenu(f"Chunk source jeopardy {i}")
         .construis()
         for i in range(15)
     ]
-
+    client_albert_memoire.avec_chunks_par_id(chunks_sources_jeopardy_totaux)
     client_albert_memoire.avec_les_resultats_par_appel(
-        [resultats_classiques, chunks_sources_jeopardy]
+        [resultats_classiques_totaux, chunks_sources_jeopardy_totaux]
     )
 
     configuration = Albert.Service(
@@ -268,4 +267,4 @@ def test_recherche_paragraphes_limite_a_20_candidats(un_reclasseur):
 
     paragraphes = service_albert.recherche_paragraphes("Ma question ?")
 
-    assert len(paragraphes) <= 20
+    assert len(paragraphes) == 10


### PR DESCRIPTION
... en retournant le même nombre de résultats pour la recherche classique et la recherche jeopardy tout en utilisant la même variable d'environnement

### Contexte
Recherche des paragraphes correspondants à une question utilisateur-rice

### Reproduction
- Poser une question sur MQC
- Vérifier les sources proposées par la réponse

### Résultat constaté
Aucune source Jeopardy remontée
<img width="2464" height="1834" alt="resultats_0" src="https://github.com/user-attachments/assets/d7a15491-75e5-4a72-b7c8-578392039aaa" />
<img width="2464" height="1818" alt="resultats_1" src="https://github.com/user-attachments/assets/6841364d-1ce6-4aab-873b-6cc64537bac2" />
<img width="2464" height="1834" alt="resultats_2" src="https://github.com/user-attachments/assets/36c6256f-2d28-460f-86b4-9bef91e4f47d" />
<img width="2464" height="1818" alt="resultats_3" src="https://github.com/user-attachments/assets/361cf259-8b26-4d83-a019-d3597d0dba30" />

### Résultat attendu 
Les sources Jeopardy sont également remontées

### Nota Bene
La recherche classique ainsi que la recherche jeopardy étaient paramètrées différemment en prenant en compte également l'activation du reclasssement.
Cela pouvait mener à des résultats excluant les questions jeopardy car la fusion de la recherche classique avec la recherche jeopardy pouvait retourner un tableau bien plus grand que le nombre de résultats attendus.
**E.g :**
 - Nombre de paragraphes retournés : 20 (paramètre pour la recherche classique)
 - Jeopardy activé 
 - Nombre de résultats jeopardy : 10 (en dur)
 
La recherche retournait successivement 20 résultats (classique) et 10 résultats (jeopardy) => 30 résultats au total. Le résultat final ne prenait en compte que les 20 premiers éléments de la recherche totale => les paragraphes jeopardy étaient donc exclus.

