### PR TITLE
[CORRECTION] Corrige la redirection exécutée par fastAPI lors de l'appel à la ressource `/source`

### DIFF
--- a/src/api/route_document_source.py
+++ b/src/api/route_document_source.py
@@ -47,7 +47,7 @@ def _recupere_les_documents(
     return conversation_recuperee, documents_trouves[0]
 
 
-@document_source.get("/", status_code=301)
+@document_source.get("", status_code=301)
 async def route_document_source(
     document: str,
     page: int,

--- a/tests/api/test_route_document_source.py
+++ b/tests/api/test_route_document_source.py
@@ -36,7 +36,7 @@ def test_redirige_vers_le_document_source(
     client_http = TestClient(serveur, follow_redirects=False)
 
     reponse = client_http.get(
-        f"/source/?document=anssi-guide-gestion_crise_cyber.pdf&page=30&interaction={str(une_interaction.id)}"
+        f"/source?document=anssi-guide-gestion_crise_cyber.pdf&page=30&interaction={str(une_interaction.id)}"
     )
 
     assert reponse.status_code == 301
@@ -85,7 +85,7 @@ def test_redirige_vers_le_bon_document_source(
     client_http = TestClient(serveur, follow_redirects=False)
 
     reponse = client_http.get(
-        f"/source/?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(une_interaction.id)}"
+        f"/source?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(une_interaction.id)}"
     )
 
     assert reponse.status_code == 301
@@ -106,7 +106,7 @@ def test_retourne_une_erreur_404_si_l_interaction_n_est_pas_trouvee(
     client_http = TestClient(serveur, follow_redirects=False)
 
     reponse = client_http.get(
-        f"/source/?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(uuid.uuid4())}"
+        f"/source?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(uuid.uuid4())}"
     )
 
     assert reponse.status_code == 404
@@ -143,7 +143,7 @@ def test_genere_une_erreur_404_si_le_document_n_est_pas_trouve(
     client_http = TestClient(serveur, follow_redirects=False)
 
     reponse = client_http.get(
-        f"/source/?document=un_document_inconnu.pdf&page=42&interaction={str(une_interaction.id)}"
+        f"/source?document=un_document_inconnu.pdf&page=42&interaction={str(une_interaction.id)}"
     )
 
     assert reponse.status_code == 404
@@ -180,7 +180,7 @@ def test_retourne_erreur_404_si_le_numero_de_page_ne_correspond_pas(
     client_http = TestClient(serveur, follow_redirects=False)
 
     reponse = client_http.get(
-        f"/source/?document=anssi-guide-gestion_crise_cyber.pdf&page=42&interaction={str(une_interaction.id)}"
+        f"/source?document=anssi-guide-gestion_crise_cyber.pdf&page=42&interaction={str(une_interaction.id)}"
     )
 
     assert reponse.status_code == 404
@@ -218,7 +218,7 @@ def test_journalise_le_document_source_demande(
     client_http = TestClient(serveur, follow_redirects=False)
 
     client_http.get(
-        f"/source/?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(une_interaction.id)}"
+        f"/source?document=anssi-guide-gestion_crise_cyber.pdf&page=25&interaction={str(une_interaction.id)}"
     )
 
     evenements = adaptateur_journal.les_evenements()

--- a/ui/src/stores/conversation.store.ts
+++ b/ui/src/stores/conversation.store.ts
@@ -86,7 +86,9 @@ const ajouteMessageUtilisateur = async (question: QuestionUtilisateur) => {
   const paragraphes: Paragraphe[] = [];
   if (estReponseConversation(reponseAPI)) {
     for await (const paragraphe of reponseAPI.paragraphes) {
-      const urlProxy = paragraphe.url.replace('/source/', '/source/proxy/');
+      const urlProxy = paragraphe.url
+        .replace('/source/', '/source')
+        .replace('/source', '/source/proxy');
       let blob: Blob = new Blob();
       try {
         blob = await adaptateurPDF.pagePDFenPNG(urlProxy, paragraphe.numero_page);

--- a/ui/tests/client.api.spec.ts
+++ b/ui/tests/client.api.spec.ts
@@ -1,0 +1,16 @@
+import { estReponseConversation } from '../src/client.api';
+import { describe, expect, it } from 'vitest';
+
+describe('la validation de réponse API', () => {
+  it('valide une réponse avec tous les champs requis incluant id de conversation', () => {
+    const reponse = {
+      reponse: 'une réponse',
+      paragraphes: [],
+      id_interaction: 'id1',
+      question: 'une question',
+      id_conversation: 'conv1',
+    };
+
+    expect(estReponseConversation(reponse)).toBe(true);
+  });
+});

--- a/ui/tests/stores/constructeurDeParagraphe.ts
+++ b/ui/tests/stores/constructeurDeParagraphe.ts
@@ -1,12 +1,19 @@
 import type { ReponseParagraphe } from '../../src/client.api';
 
 class ConstructeurDeParagraphe {
+  private _urlDocument: string = 'http://mqc.local';
+
+  avecURLDocument(urlDocument: string): ConstructeurDeParagraphe {
+    this._urlDocument = urlDocument;
+    return this;
+  }
+
   construis(): ReponseParagraphe {
     return {
       contenu: 'Un contenu',
       nom_document: 'Un document',
       numero_page: 12,
-      url: 'http://mqc.local',
+      url: this._urlDocument,
       titre: 'Un titre',
       date_mise_a_jour: '2026-07-12T21:23:00:000Z',
     };

--- a/ui/tests/stores/conversation.store.spec.ts
+++ b/ui/tests/stores/conversation.store.spec.ts
@@ -3,7 +3,7 @@ import {
   nettoyeurDOM,
   storeConversation,
 } from '../../src/stores/conversation.store';
-import { clientAPI, estReponseConversation } from '../../src/client.api';
+import { clientAPI } from '../../src/client.api';
 import { get } from 'svelte/store';
 import { storeAffichage } from '../../src/stores/affichage.store';
 import { unConstructeurParagraphe } from './constructeurDeParagraphe';
@@ -267,61 +267,97 @@ describe('le store de conversation', () => {
     });
   });
 
-  it('continue la génération PDF en cas d’erreur', async () => {
-    let nombreAppel = 0;
-    adaptateurPDF.pagePDFenPNG = () => {
-      nombreAppel++;
-      if (nombreAppel === 3) {
-        throw new InvalidPDFException('PDF en erreur');
-      }
-      return Promise.resolve(new Blob());
-    };
-    clientAPI.ajouteInteraction = async () => ({
-      reponse: 'Une réponse',
-      question: 'Une question',
-      paragraphes: [
-        unConstructeurParagraphe().construis(),
-        unConstructeurParagraphe().construis(),
-        unConstructeurParagraphe().construis(),
-        unConstructeurParagraphe().construis(),
-      ],
-      id_interaction: 'id-interaction',
+  describe('pour la génération des PDF', () => {
+    it('continue la génération en cas d’erreur', async () => {
+      let nombreAppel = 0;
+      adaptateurPDF.pagePDFenPNG = () => {
+        nombreAppel++;
+        if (nombreAppel === 3) {
+          throw new InvalidPDFException('PDF en erreur');
+        }
+        return Promise.resolve(new Blob());
+      };
+      clientAPI.ajouteInteraction = async () => ({
+        reponse: 'Une réponse',
+        question: 'Une question',
+        paragraphes: [
+          unConstructeurParagraphe().construis(),
+          unConstructeurParagraphe().construis(),
+          unConstructeurParagraphe().construis(),
+          unConstructeurParagraphe().construis(),
+        ],
+        id_interaction: 'id-interaction',
+      });
+      storeConversation.initialise({
+        messages: [
+          { contenu: 'une question ?', emetteur: 'utilisateur' },
+          {
+            contenu: 'une réponse',
+            contenuMarkdown: 'une réponse',
+            emetteur: 'systeme',
+            references: [],
+            idInteraction: 'id-interaction',
+          },
+        ],
+        derniereQuestion: 'une question ?',
+        idConversation: 'id-conversation',
+      });
+
+      await storeConversation.ajouteMessageUtilisateur({
+        question: 'Une question ?',
+      });
+
+      const storeMisAJour = get(storeConversation);
+      const paragraphes = storeMisAJour.messages[3].references;
+      expect(paragraphes).toBeDefined();
+      expect(paragraphes!.every((p) => p.image !== undefined)).toBe(true);
+      expect(paragraphes).toHaveLength(4);
     });
-    storeConversation.initialise({
-      messages: [
-        { contenu: 'une question ?', emetteur: 'utilisateur' },
-        {
-          contenu: 'une réponse',
-          contenuMarkdown: 'une réponse',
-          emetteur: 'systeme',
-          references: [],
-          idInteraction: 'id-interaction',
-        },
-      ],
-      derniereQuestion: 'une question ?',
-      idConversation: 'id-conversation',
+
+    it('remplace correctement l‘url du document source', async () => {
+      const urlAppelees: string[] = [];
+      adaptateurPDF.pagePDFenPNG = (url: string) => {
+        urlAppelees.push(url);
+        return Promise.resolve(new Blob());
+      };
+      clientAPI.ajouteInteraction = async () => ({
+        reponse: 'Une réponse',
+        question: 'Une question',
+        paragraphes: [
+          unConstructeurParagraphe()
+            .avecURLDocument('http://demo.local/source/?document=mon-doc-1.pdf')
+            .construis(),
+          unConstructeurParagraphe()
+            .avecURLDocument('http://demo.local/source?document=mon-doc-2.pdf')
+            .construis(),
+        ],
+        id_interaction: 'id-interaction',
+      });
+      storeConversation.initialise({
+        messages: [
+          { contenu: 'une question ?', emetteur: 'utilisateur' },
+          {
+            contenu: 'une réponse',
+            contenuMarkdown: 'une réponse',
+            emetteur: 'systeme',
+            references: [],
+            idInteraction: 'id-interaction',
+          },
+        ],
+        derniereQuestion: 'une question ?',
+        idConversation: 'id-conversation',
+      });
+
+      await storeConversation.ajouteMessageUtilisateur({
+        question: 'Une question ?',
+      });
+
+      expect(urlAppelees[0]).toEqual(
+        'http://demo.local/source/proxy?document=mon-doc-1.pdf'
+      );
+      expect(urlAppelees[1]).toEqual(
+        'http://demo.local/source/proxy?document=mon-doc-2.pdf'
+      );
     });
-
-    await storeConversation.ajouteMessageUtilisateur({ question: 'Une question ?' });
-
-    const storeMisAJour = get(storeConversation);
-    const paragraphes = storeMisAJour.messages[3].references;
-    expect(paragraphes).toBeDefined();
-    expect(paragraphes!.every((p) => p.image !== undefined)).toBe(true);
-    expect(paragraphes).toHaveLength(4);
-  });
-});
-
-describe('la validation de réponse API', () => {
-  it('valide une réponse avec tous les champs requis incluant id de conversation', () => {
-    const reponse = {
-      reponse: 'une réponse',
-      paragraphes: [],
-      id_interaction: 'id1',
-      question: 'une question',
-      id_conversation: 'conv1',
-    };
-
-    expect(estReponseConversation(reponse)).toBe(true);
   });
 });


### PR DESCRIPTION
### Contexte
Réponse retournées par MQC lorsqu'un•e utilisateur•rice pose une question

### Reproduction
- **Pré-requis :** Ouvrir la console dévelopeur du navigateur
- Se rendre sur MQC
- Poser une question
- Observer les échanges réseaux dans la console lorsque l'on génère les images à partir du PDF (i.e : `source/proxy?document=`)

### Résultat constaté
- Chaque appel est suivi d'une redirection 307 de la part du serveur
- Les images ne sont pas chargée car sur l'environnement de démo (déployé le 22/07/2026 sur CC derrière le mtls mis en place ce même jour avec un nouveau load balancer) la redirection génère une erreur de CSP car redirige vers du `http` au lieu de `https`

### Résultat attendu
- Aucune redirection n'est faite, le serveur traite la requête directement
- Les images sont chargées

### Nota bene
Le problème est apparu lorsque l'environnement de démo sur CC a été modifié suite à l'apparition du mtls (entre OGO et CC) sur cet environnement et la mise en place d'un nouveau load balancer.
Les images de prévisualisation des PDF n'étaient pas générées car une erreur CSP était levée due à une redirection côté serveur vers `http://demo.mesquestionscyber.beta.gouv.fr` (CSP positionnées sur self dans connect-src, le changement de protocole casse donc cette CSP).

Nous avons donc modifié le comportement de la ressource de fastAPI pour éviter ces redirections.

**:warning: La collection documentaire est configurée avec les URL de la forme `/source/?document=mon-doc-1.pdf`**
La correction prend en compte ce format mais à l'avenir il faudrait modifier MQC data pour générer l'URL sans le `/` après `source`